### PR TITLE
Add AdDogs to Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@
 - [Copy.ai](https://www.copy.ai/): AI to polish your blogs and rewrite sentences. AI to write marketing and social media titles and descriptions for sales.
 - [Jasper](https://www.jasper.ai/): Generative AI platform for business that helps your team create content tailored for your brand 10x faster, in social media, advertising, and content.
 - [Serplux](https://serplux.com/): Supercharge your SEO and content workflows with Serplux's AI-powered agents. Automate insights, accelerate organic growth, and unlock revenue - all without lifting a finger.
+- [AdDogs](https://www.addogs.ai): AI ad creative generator. Clone any winning ad design, swap in your product photo, apply your brand colors and logo in 10 seconds. Built for e-commerce and DTC brands.
 
 
 ## Podcast


### PR DESCRIPTION
Adds AdDogs to the Marketing section.

**Name:** AdDogs
**URL:** https://www.addogs.ai
**Section:** Marketing
**Description:** AI ad creative generator. Clone any winning ad design, swap in your product photo, apply your brand colors and logo in 10 seconds. Built for e-commerce and DTC brands.

Entry placed at the end of the Marketing section matching the existing `- [Name](url): description.` format. Thanks for curating this list!