### PR TITLE
Add CreatorSkills to Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@
 - [Serplux](https://serplux.com/): Supercharge your SEO and content workflows with Serplux's AI-powered agents. Automate insights, accelerate organic growth, and unlock revenue - all without lifting a finger.
 - [toprank](https://github.com/nowork-studio/toprank) - Open-source Claude Code plugin for SEO and Google Ads. Connects Google Search Console, PageSpeed Insights, and Google Ads API to automate meta tag rewrites, schema markup, keyword bids, and content pushes to WordPress/Strapi/Contentful/Ghost.
 - [AdDogs](https://www.addogs.ai): AI ad creative generator. Clone any winning ad design, swap in your product photo, apply your brand colors and logo in 10 seconds. Built for e-commerce and DTC brands.
+- [CreatorSkills](https://creatorskills.co): Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.
 
 
 ## Podcast


### PR DESCRIPTION
Adds [CreatorSkills](https://creatorskills.co) to the Marketing section alongside Copy.ai and Jasper.

CreatorSkills is a marketplace of 30+ downloadable AI skills (prompt instructions) for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT — a strong fit for marketers and content creators using this list.