### PR TITLE
feat: add NotFair - open-source Claude Code skills for SEO & paid ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 - [Jasper](https://www.jasper.ai/): Generative AI platform for business that helps your team create content tailored for your brand 10x faster, in social media, advertising, and content.
 - [Serplux](https://serplux.com/): Supercharge your SEO and content workflows with Serplux's AI-powered agents. Automate insights, accelerate organic growth, and unlock revenue - all without lifting a finger.
 - [toprank](https://github.com/nowork-studio/toprank) - Open-source Claude Code plugin for SEO and Google Ads. Connects Google Search Console, PageSpeed Insights, and Google Ads API to automate meta tag rewrites, schema markup, keyword bids, and content pushes to WordPress/Strapi/Contentful/Ghost.
+- [NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. Connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP to automate site audits, keyword research, meta tags, schema markup, and paid-ads management.
 - [AdDogs](https://www.addogs.ai): AI ad creative generator. Clone any winning ad design, swap in your product photo, apply your brand colors and logo in 10 seconds. Built for e-commerce and DTC brands.
 
 


### PR DESCRIPTION
Hi! Thanks for maintaining this list — it's a great resource.

I'd like to add **NotFair** ([github.com/nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)), an open-source set of Claude Code agent skills for marketing work. It covers SEO (site analysis, keyword research, meta tags, schema markup, GEO optimization), Google Ads (audits, wasted-spend detection, bid management), and Meta Ads (ROAS analysis, creative fatigue, audience overlap). It pulls live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. It has around ~2.9k stars on GitHub.

I added it to the Marketing section right alongside the existing toprank entry, since the topic and format match exactly.

Happy to reword, move, or trim the entry if needed. Thanks again!