### PR TITLE
Add LLMGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
 - [Imgcreator AI](https://imgcreator.ai/) - Text to image, image to image & chatGPT powered AI designer. Upload a photo of your space,let AI remodel your dream room in seconds
 
 ## Build Apps with AI
+- [LLMGraph](https://llmgraph.ai/) - No-code visual builder for LLM workflows. Turn your docs and models into RAG chatbots and AI agents, then deploy each to a REST API and an embeddable chat widget in one click.
 - [Sitekick AI](https://www.sitekick.ai/) - Creates landing pages in minutes.
 - [Auto code](https://autocode.com/) - Turn ideas into software with AI. No more reading API documentation. Build JavaScript-powered bots, scripts and APIs with code generation and instant deployment.
 - [MakeReal.TLDraw](https://makereal.tldraw.com/) - Turn Hand drawn Sketches into Apps . [github](https://github.com/tldraw/make-real?tab=readme-ov-file)


### PR DESCRIPTION
Adds **LLMGraph** (https://llmgraph.ai) — a no-code visual builder for LLM workflows. Build AI workflows on a drag-and-drop canvas or by describing them in chat, turn your docs/models into RAG chatbots and AI agents, and deploy each to a REST API + embeddable chat widget in one click. Placed in the most relevant section, matching the existing entry format.