### PR TITLE
Add AISO Tools under Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@
 - [Serplux](https://serplux.com/): Supercharge your SEO and content workflows with Serplux's AI-powered agents. Automate insights, accelerate organic growth, and unlock revenue - all without lifting a finger.
 - [toprank](https://github.com/nowork-studio/toprank) - Open-source Claude Code plugin for SEO and Google Ads. Connects Google Search Console, PageSpeed Insights, and Google Ads API to automate meta tag rewrites, schema markup, keyword bids, and content pushes to WordPress/Strapi/Contentful/Ghost.
 - [AdDogs](https://www.addogs.ai): AI ad creative generator. Clone any winning ad design, swap in your product photo, apply your brand colors and logo in 10 seconds. Built for e-commerce and DTC brands.
+- [AISO Tools](https://aisotools.com/): Audits whether ChatGPT, Perplexity, and Google AI Overviews actually recommend your site for the queries your buyers ask, and reports which citations and gaps are blocking it. Free audit; the catalog is also queryable over MCP.
 
 
 ## Podcast


### PR DESCRIPTION
One row appended to **Marketing**, matching the existing `- [Name](url): description` format.

The section already carries SEO tooling (Serplux, toprank) — both aimed at ranking in Google. AISO Tools is the same job pointed at the answer engines instead: it runs your queries against ChatGPT, Perplexity, and Google AI Overviews and reports whether you get recommended, who gets recommended instead, and which gaps block the citation. Free audit, no card.

Verified before filing: https://aisotools.com/ returns 200 (checked with a Googlebot UA too), and the MCP endpoint mentioned in the description answers a real `tools/list` — 5 tools over a 1,636-tool catalog.

**Disclosure:** I maintain AISO Tools. Happy to shorten the line or close this if Marketing is not the right home for it.