### PR TITLE
Add videos.social to Video Generation and Editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - [elai.io](https://elai.io/): Paid - Create AI videos from just text. Build customized AI videos with a presenter in minutes without using a camera, studio and a green screen.
 - [Make-A-Video](https://makeavideo.studio/): Make-A-Video of Meta AI. State-of-the-art AI system that generates videos from text.
 - [Pictory.ai](https://pictory.ai/): Turn Scripts Into Jaw-Dropping Sales Videos. Transform Blog Posts Into Engaging Videos On Auto-Pilot. 
+- [videos.social](https://videos.social/?utm_source=awesome-ai-saas&utm_medium=directory&utm_campaign=listing-wave-d): Turn blogs, PDFs, and prompts into editable faceless videos. Start free — 1 render included.
 - [invideo.io](https://invideo.io/): InVideo simplifies video creation with ready-made templates that you can quickly customize even if you’ve never done it before.
 - [move.ai](https://www.move.ai/) - Helps convert normal videos to 3D and  bring motion into digital worlds at a limitless scale
 - [Wav2Lip](https://github.com/Rudrabha/Wav2Lip) - Accurately Lip-syncing Videos to the given Audio


### PR DESCRIPTION
Adds videos.social under **Video Generation and Editing**, next to Pictory.ai / invideo.io.

videos.social turns blogs, PDFs, and prompts into editable faceless videos (script, scenes, voiceover) rather than a locked regenerate loop. Start free — 1 render included. Packs from $10. 1 credit = 1 render.

Public, usable product in the same class as Pictory.ai and invideo.io. Not a duplicate.

Disclosure: submitted by the videos.social team.