### PR TITLE
Add XiuRouter to Hosted ML Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@
 
 ## Hosted ML Models
 - [replicate](https://replicate.com/home) - Run AI with an API.
+- [XiuRouter](https://router.xiu.ai/) - Usage-based model API service with OpenAI Chat Completions and Responses, Anthropic Messages, Gemini GenerateContent, scoped API keys, and request-level usage and cost records.
 
 ##
 ##


### PR DESCRIPTION
## Summary

- add XiuRouter to the Hosted ML Models section
- describe its supported API protocols, scoped keys, and request-level usage records

## Why it fits

XiuRouter is a developer-facing model API service used by coding agents and other applications. The entry stays in the existing one-line format and links to the canonical product page.

## Verification

- `git diff --check`
- XiuRouter homepage returns HTTP 200
- no existing XiuRouter or router.xiu.ai entry was found in the README or open/closed pull requests before submission

Disclosure: I am submitting this on behalf of XiuRouter, operated by XiuLab Inc. The change was drafted with AI assistance and reviewed against the public product and integration pages.